### PR TITLE
changes linking to CatchDetails

### DIFF
--- a/Frontend/app/catchdetails/page.tsx
+++ b/Frontend/app/catchdetails/page.tsx
@@ -72,7 +72,7 @@ export default function CatchDetailsPage() {
         <div className="mx-[150] my-[40]">
           <CatchDetailsTable
             assetDetails={assetDetails}
-            editableFields={editableFields}
+            editableFields={isDetailsSaved ? [] : editableFields} // Disable editing when saved
           />
         </div>
 

--- a/Frontend/app/homepage/fisher/page.tsx
+++ b/Frontend/app/homepage/fisher/page.tsx
@@ -40,12 +40,8 @@ export default function FisherHomepage() {
       {/* Tuna Grid */}
       <div className="grid grid-cols-3 gap-6">
         {filteredTunaData.map((tuna) => (
-          <Link href="/viewdetails" key={tuna.id}>
-            <TunaCard
-              id={tuna.id}
-              date={tuna.date}
-              status={tuna.status}
-            />
+          <Link href="/viewzdetails" key={tuna.id}>
+            <TunaCard id={tuna.id} date={tuna.date} status={tuna.status} />
           </Link>
         ))}
       </div>

--- a/Frontend/app/homepage/retailer/page.tsx
+++ b/Frontend/app/homepage/retailer/page.tsx
@@ -38,7 +38,7 @@ export default function RetailerHomepage() {
       {/* Tuna Grid */}
       <div className="grid grid-cols-3 gap-6">
         {filteredTunaData.map((tuna) => (
-          <Link href="/viewdetails" key={tuna.id}>
+          <Link href="/catchdetails" key={tuna.id}>
             <TunaCard id={tuna.id} date={tuna.date} status={tuna.status} />
           </Link>
         ))}

--- a/Frontend/app/homepage/supplier/page.tsx
+++ b/Frontend/app/homepage/supplier/page.tsx
@@ -38,7 +38,7 @@ export default function SupplierHomepage() {
       {/* Tuna Grid */}
       <div className="grid grid-cols-3 gap-6">
         {filteredTunaData.map((tuna) => (
-          <Link href="/viewdetails" key={tuna.id}>
+          <Link href="/catchdetails" key={tuna.id}>
             <TunaCard id={tuna.id} date={tuna.date} status={tuna.status} />
           </Link>
         ))}

--- a/Frontend/components/CatchTable.tsx
+++ b/Frontend/components/CatchTable.tsx
@@ -1,5 +1,8 @@
+"use client";
+
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Pencil } from "lucide-react";
+import { Pencil, Check } from "lucide-react";
 
 type AssetDetail = {
   label: string;
@@ -15,6 +18,28 @@ export default function CatchDetailsTable({
   assetDetails,
   editableFields = [],
 }: CatchDetailsTableProps) {
+  const [editingField, setEditingField] = useState<string | null>(null);
+  const [editedValues, setEditedValues] = useState<{ [key: string]: string }>(
+    Object.fromEntries(assetDetails.map((item) => [item.label, item.value]))
+  );
+  const handleEditClick = (label: string) => {
+    if (!editableFields.includes(label)) return; // Prevent editing if not allowed
+    setEditingField(label);
+  };
+
+  const handleInputChange = (label: string, newValue: string) => {
+    if (label === "Weight (kg)" && !/^\d*\.?\d*$/.test(newValue)) return;
+    if (
+      ["Species", "Catch Location", "Fishing Method"].includes(label) &&
+      /[^a-zA-Z\s]/.test(newValue)
+    )
+      return;
+    setEditedValues((prev) => ({ ...prev, [label]: newValue }));
+  };
+
+  const handleSave = () => {
+    setEditingField(null);
+  };
   return (
     <div className="bg-white shadow-lg">
       {assetDetails.map((item, index) => (
@@ -24,13 +49,49 @@ export default function CatchDetailsTable({
         >
           <span className="font-medium">{item.label}</span>
           <div className="flex items-center gap-2">
-            <span>{item.value}</span>
-            {editableFields.includes(item.label) && (
-              <Button variant={"ghost"} size="icon">
-                <Pencil
-                  className="w-4 h-4 text-black-500 cursor-pointer"
-                  strokeWidth={3}
+            {editingField === item.label ? (
+              item.label === "Catch Date" ? (
+                <input
+                  type="date"
+                  value={editedValues[item.label]}
+                  onChange={(e) =>
+                    handleInputChange(item.label, e.target.value)
+                  }
+                  onBlur={handleSave}
+                  className="border p-1 rounded"
                 />
+              ) : (
+                <input
+                  type="text"
+                  value={editedValues[item.label]}
+                  onChange={(e) =>
+                    handleInputChange(item.label, e.target.value)
+                  }
+                  onBlur={handleSave}
+                  onKeyDown={(e) => e.key === "Enter" && handleSave()}
+                  autoFocus
+                  className="border p-1 rounded"
+                />
+              )
+            ) : (
+              <span>{editedValues[item.label]}</span>
+            )}
+
+            {editableFields.includes(item.label) && (
+              <Button
+                variant={"ghost"}
+                size="icon"
+                onClick={() =>
+                  editingField === item.label
+                    ? handleSave()
+                    : handleEditClick(item.label)
+                }
+              >
+                {editingField === item.label ? (
+                  <Check className="w-4 h-4 text-green-500" strokeWidth={3} />
+                ) : (
+                  <Pencil className="w-4 h-4 text-black-500" strokeWidth={3} />
+                )}
               </Button>
             )}
           </div>


### PR DESCRIPTION
+ Supplier&Retailer goes to catchdetails page when click cards in their homepages

+ Made values editable in the CatchTable, with specific type values for labels

+ Remove editing once saved